### PR TITLE
feat: change storage key prefix

### DIFF
--- a/src/storage/base-storage.test.ts
+++ b/src/storage/base-storage.test.ts
@@ -48,7 +48,7 @@ describe('BrowserStorage', () => {
       storage.set('test', 'value');
 
       const call = vi.mocked(mockStorage.setItem).mock.calls[0];
-      expect(call[0]).toMatch(/^datanova\.sdk\.[a-z0-9]{6}\.test$/);
+      expect(call[0]).toMatch(/^datanova\.sdk\.browser\.[a-z0-9]{4}\.test$/);
 
       window.localStorage = originalLocalStorage;
     });

--- a/src/storage/base-storage.ts
+++ b/src/storage/base-storage.ts
@@ -15,8 +15,8 @@ export class BrowserStorage {
       this.prefix = customPrefix;
     } else {
       const origin = typeof window !== 'undefined' ? window.location.origin : 'default';
-      const originHash = this.hashString(origin).toString(36).slice(-6);
-      this.prefix = `datanova.sdk.${originHash}.`;
+      const originHash = this.hashString(origin).toString(36).slice(-4);
+      this.prefix = `datanova.sdk.browser.${originHash}.`;
     }
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the storage key prefix format for browser storage, resulting in a shorter and more descriptive prefix for stored items. This change improves key organization but does not affect existing data or user interactions.

* **Tests**
  * Adjusted tests to reflect the new storage key prefix format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->